### PR TITLE
bump minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 PROJECT(mdio-tool)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
CMake 4.0.0 no longer supports features deprecated in CMake 3.5 or earlier. Bump the minimum version to allow building with current CMake.